### PR TITLE
Line 164  z-score transformation formula

### DIFF
--- a/vignettes/Lab8_Normal.Rmd
+++ b/vignettes/Lab8_Normal.Rmd
@@ -161,7 +161,7 @@ Z-scores are linear transformations. They convert the raw values from a normal d
 
 The z-score transformation is:
 
-$z_i = \frac{u - x_i}{\sigma}$ or $z_i = \frac{\text{mean} - \text{score}}{\text{standard deviation}}$
+$z_i = \frac{x_i - u}{\sigma}$ or $z_i = \frac{\text{score} - \text{mean}}{\text{standard deviation}}$
 
 There are two important transformations in the formula. The subtraction centers the scores on the mean. The division expresses the scores in terms of a common unit (which is sometimes why z-scores are also called standard scores, they have been "standardized", in this case by a "standard deviation").
 


### PR DESCRIPTION
Hello Professor Crump, In your written and video lecture, you explained that "the centering transformation causes all values below the mean to receive a negative z-score, while all values above the mean to have a positive z-score."  According to the formula in our written lecture, the opposite is true (i.e., scores below the mean receive a positive number, and scores above the mean receive a negative number).   I adjusted the numerator of the formula, which I think is a typo.